### PR TITLE
修复饼状图和圆环图在数据option为数字时的显示错误

### DIFF
--- a/wjcat/src/components/DataShow.vue
+++ b/wjcat/src/components/DataShow.vue
@@ -316,18 +316,22 @@ export default {
     },
     // 饼状图
     setPar(id) {
+      console.log(id);
+      console.log(this.detail[id].result);
       let myChart = echarts.init(document.getElementById("bing" + id));
+
+      var myData = [];
+      let formData = this.detail[id].result;
+      for(let i = 0; i < formData.length; i++) {
+        let element = formData[i];
+        let item = {name: element.option, value: element.count};
+        myData.push(item);
+      }
+
       var option = {
         tooltip: {},
-
+        legend: {},
         color: ["#409EFF", "#FFB54D", "#FF7466", "#44DB5E"],
-        legend: {
-          data: ["数量"]
-        },
-        dataset: {
-          dimensions: ["option", "count", "percent"],
-          source: this.detail[id].result
-        },
         series: [
           {
             name: "统计结果：",
@@ -340,7 +344,8 @@ export default {
                 shadowOffsetX: 0,
                 shadowColor: "rgba(0, 0, 0, 0.5)"
               }
-            }
+            },
+            data: myData
           }
         ]
       };
@@ -350,20 +355,26 @@ export default {
     setRing(id) {
       //console.log(id);
       let myChart = echarts.init(document.getElementById("ring" + id));
+
+      var myData = [];
+      let formData = this.detail[id].result;
+      for(let i = 0; i < formData.length; i++) {
+        let element = formData[i];
+        let item = {name: element.option, value: element.count};
+        myData.push(item);
+      }
+
       var option = {
         tooltip: {},
         legend: {},
         color: ["#409EFF", "#FFB54D", "#FF7466", "#44DB5E"],
-        dataset: {
-          dimensions: ["option", "count", "percent"],
-          source: this.detail[id].result
-        },
         series: [
           {
             name: "数量：",
             type: "pie",
             radius: ["50%", "70%"],
             avoidLabelOverlap: false,
+            data: myData,
             label: {
               normal: {
                 show: false,
@@ -387,7 +398,7 @@ export default {
       };
       myChart.setOption(option);
     },
-    //圆环图
+    //条状图
     setTz(id) {
       //console.log(id);
       let myChart = echarts.init(document.getElementById("tz" + id));


### PR DESCRIPTION
修复饼状图和圆环图在数据option为数字时的显示错误，修复前：
![image](https://github.com/shanghaobo/wjcat-release/assets/59681827/166b79be-1553-49a6-8df2-17448266b6fd)
修复后：
![image](https://github.com/shanghaobo/wjcat-release/assets/59681827/848f48a4-f803-405d-9398-40755ad5d4ce)
